### PR TITLE
Optimize Firestore queries for performance and cost.

### DIFF
--- a/src/hooks/use-life-quest-store.tsx
+++ b/src/hooks/use-life-quest-store.tsx
@@ -28,6 +28,8 @@ import {
   Timestamp,
   writeBatch,
   orderBy,
+  where,
+  limit,
 } from 'firebase/firestore';
 import { useAuth } from './use-auth';
 import { format, startOfDay, subDays, isEqual } from 'date-fns'; // Added subDays, isEqual
@@ -97,7 +99,7 @@ export const LifeQuestProvider = ({ children }: { children: ReactNode }) => {
       setPlayer(null);
     });
 
-    const tasksQuery = query(collection(db, 'players', userId, 'tasks'), orderBy('createdAt', 'desc'));
+    const tasksQuery = query(collection(db, 'players', userId, 'tasks'), where('status', 'in', ['To Do', 'In Progress']), orderBy('createdAt', 'desc'), limit(50));
     const unsubscribeTasks = onSnapshot(tasksQuery, (querySnapshot) => {
       const tasksData = querySnapshot.docs.map(doc => {
         const data = doc.data();
@@ -111,7 +113,7 @@ export const LifeQuestProvider = ({ children }: { children: ReactNode }) => {
       setTasks(tasksData);
     }, (error) => console.error(`Error fetching tasks for UID ${userId}:`, error));
 
-    const habitsQuery = query(collection(db, 'players', userId, 'habits'), orderBy('createdAt', 'desc'));
+    const habitsQuery = query(collection(db, 'players', userId, 'habits'), orderBy('createdAt', 'desc'), limit(50));
     const unsubscribeHabits = onSnapshot(habitsQuery, (querySnapshot) => {
       const habitsData = querySnapshot.docs.map(docSnap => { // Renamed to docSnap to avoid conflict
         const data = docSnap.data();
@@ -141,7 +143,7 @@ export const LifeQuestProvider = ({ children }: { children: ReactNode }) => {
       setHabits(habitsData);
     }, (error) => console.error(`Error fetching habits for UID ${userId}:`, error));
 
-    const rewardsQuery = query(collection(db, 'players', userId, 'rewards'), orderBy('createdAt', 'desc'));
+    const rewardsQuery = query(collection(db, 'players', userId, 'rewards'), orderBy('createdAt', 'desc'), limit(50));
     const unsubscribeRewards = onSnapshot(rewardsQuery, (querySnapshot) => {
       const rewardsData = querySnapshot.docs.map(doc => { // Renamed to avoid conflict
         const data = doc.data();


### PR DESCRIPTION
This commit introduces several optimizations to Firestore queries within the `use-life-quest-store.tsx` hook:

1.  **Tasks Query Optimization:**
    *   Filters tasks to include only those with status 'To Do' or 'In Progress' by default (`where('status', 'in', ['To Do', 'In Progress'])`).
    *   Limits the query to the 50 most recent tasks (`limit(50)`).
    *   This aims to reduce the number of documents read and improve initial load performance.

2.  **Habits Query Optimization:**
    *   Limits the query to the 50 most recent habits (`limit(50)`).
    *   Improves initial load performance for you if you have many habits.

3.  **Rewards Query Optimization:**
    *   Limits the query to the 50 most recent rewards (`limit(50)`).
    *   Improves initial load performance for you if you have many rewards.

**Indexing Recommendations:**

To support these query changes and ensure optimal performance, the following Firestore indexes should be created or verified in the Firebase console for each of your subcollections:

*   **For the `tasks` subcollection (e.g., `players/{userId}/tasks`):**
    *   Composite Index: `status ASC, createdAt DESC` (or `status DESC, createdAt DESC`)

*   **For the `habits` subcollection (e.g., `players/{userId}/habits`):**
    *   Single-Field Index: `createdAt DESC` (if not auto-created)

*   **For the `rewards` subcollection (e.g., `players/{userId}/rewards`):**
    *   Single-Field Index: `createdAt DESC` (if not auto-created)

These changes aim to make the application more efficient in its data fetching, leading to faster load times and potentially lower Firestore costs.